### PR TITLE
Downgrade to .netstandart 2.0

### DIFF
--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -6,7 +6,7 @@
 
         <RootNamespace>NFun.Examples</RootNamespace>
 
-        <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netcoreapp3.1;net461</TargetFrameworks>
 
         <LangVersion>10</LangVersion>
     </PropertyGroup>

--- a/src/Benchmarks/NFun.Benchmarks/NFun.Benchmarks.csproj
+++ b/src/Benchmarks/NFun.Benchmarks/NFun.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFrameworks>net5.0;net461</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
 

--- a/src/NFun/Functions/ConvertFunction.cs
+++ b/src/NFun/Functions/ConvertFunction.cs
@@ -82,23 +82,23 @@ public class ConvertFunction : GenericFunctionBase {
                    BaseFunnyType.UInt8 => o => Convert.ToByte((char)o),
                    BaseFunnyType.UInt16 => o => GetUnicodeBytes(o, out var bytes) > 2 
                        ? throw new OverflowException($"Cannot convert char value '{o}' to unt16") 
-                       : BitConverter.ToUInt16(bytes),
+                       : BitConverter.ToUInt16(bytes,0),
                    BaseFunnyType.Int16 => o => GetUnicodeBytes(o, out var bytes) > 2 
                        ? throw new OverflowException($"Cannot convert char value '{o}' to int16") 
-                       : BitConverter.ToInt16(bytes),
+                       : BitConverter.ToInt16(bytes, 0),
                    BaseFunnyType.UInt32 => o => GetUnicodeBytes(o, out var bytes) > 4 
                        ? throw new OverflowException($"Cannot convert char value '{o}' to unt32") 
-                       : BitConverter.ToUInt32(bytes),
+                       : BitConverter.ToUInt32(bytes, 0),
                    BaseFunnyType.Int32 => o => GetUnicodeBytes(o, out var bytes) > 4 
                        ? throw new OverflowException($"Cannot convert char value '{o}' to int32") 
-                       : BitConverter.ToInt32(bytes) ,
+                       : BitConverter.ToInt32(bytes, 0) ,
                    BaseFunnyType.UInt64 => o => {
                        GetUnicodeBytes(o, out var bytes);
-                       return BitConverter.ToUInt64(bytes);
+                       return BitConverter.ToUInt64(bytes, 0);
                    },
                    BaseFunnyType.Int64 => o => {
                        GetUnicodeBytes(o, out var bytes);
-                       return BitConverter.ToInt64(bytes);
+                       return BitConverter.ToInt64(bytes, 0);
                    },
                    _                   => null
                };

--- a/src/NFun/Helper.cs
+++ b/src/NFun/Helper.cs
@@ -111,3 +111,48 @@ internal static class Helper {
         return ans;
     }
 }
+//netstandard 2.0 tuple deconstruct helper extension
+static class KvpExtensions
+{
+    public static void Deconstruct<TKey, TValue>(
+        this KeyValuePair<TKey, TValue> kvp,
+        out TKey key,
+        out TValue value)
+    {
+        key = kvp.Key;
+        value = kvp.Value;
+    }
+}
+
+static class QueueExtensions
+{
+    public static bool TryPeek<TValue>(
+        this Queue<TValue> queue,
+        out TValue result)
+    {
+        if (queue.IsEmpty())
+        {
+            result = default;
+            return false;
+        }
+        result = queue.Peek();
+        return true;
+    }
+}
+static class DictionaryExtensions
+{
+    public static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+    {
+        //perfomance hit, double key retrieving.
+        if (!dictionary.ContainsKey(key))
+            return default;
+        return dictionary[key];
+    }
+    public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
+    {
+        //perfomance hit, double key retrieving.
+        if (!dictionary.ContainsKey(key))
+            return defaultValue;
+        return dictionary[key];
+    }
+}

--- a/src/NFun/NFun.csproj
+++ b/src/NFun/NFun.csproj
@@ -24,6 +24,7 @@
 
     <ItemGroup>
       <None Remove="NFun.nuspec" />
+      <PackageReference Include="IndexRange" Version="1.0.2" />
       <PackageReference Include="System.Memory" Version="4.5.5" />
       <None Update="Functions\GenericSwitchFunctionsGenerated.tt">
         <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/NFun/NFun.csproj
+++ b/src/NFun/NFun.csproj
@@ -17,13 +17,14 @@
         <PackageReleaseNotes>Decimal support, Improve error info</PackageReleaseNotes>
         <AssemblyVersion>0.9.8</AssemblyVersion>
         <FileVersion>0.9.8</FileVersion>
-        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 
     </PropertyGroup>
 
     <ItemGroup>
       <None Remove="NFun.nuspec" />
+      <PackageReference Include="System.Memory" Version="4.5.5" />
       <None Update="Functions\GenericSwitchFunctionsGenerated.tt">
         <Generator>TextTemplatingFileGenerator</Generator>
         <LastGenOutput>GenericSwitchFunctionsGenerated.cs</LastGenOutput>

--- a/src/NFun/Tic/SolvingFunctions.cs
+++ b/src/NFun/Tic/SolvingFunctions.cs
@@ -42,7 +42,7 @@ public static class SolvingFunctions {
             case StateStruct strA when stateB is StateStruct strB:
             {
                 var result = new Dictionary<string, TicNode>();
-                foreach (var (key, value) in strA.Fields)
+                foreach ((var key,var value) in strA.Fields)
                 {
                     var bNode = strB.GetFieldOrNull(key);
                     if (bNode != null)

--- a/src/NFun/Tokenization/TokenHelper.cs
+++ b/src/NFun/Tokenization/TokenHelper.cs
@@ -10,7 +10,7 @@ public static class TokenHelper {
     public static (object, FunnyType) ToConstant(string val) {
         val = val.Replace("_", null);
 
-        if (val.Contains('.'))
+        if (val.Contains("."))
         {
             if (val.EndsWith("."))
                 throw new FormatException();

--- a/src/NFun/Types/TypeBehaviour.cs
+++ b/src/NFun/Types/TypeBehaviour.cs
@@ -124,23 +124,23 @@ public abstract class TypeBehaviour {
             BaseFunnyType.UInt8 => o => Convert.ToByte((char)o),
             BaseFunnyType.UInt16 => o => GetUnicodeBytes(o, out var bytes) > 2
                 ? throw new OverflowException($"Cannot convert char value '{o}' to unt16")
-                : BitConverter.ToUInt16(bytes),
+                : BitConverter.ToUInt16(bytes, 0),
             BaseFunnyType.Int16 => o => GetUnicodeBytes(o, out var bytes) > 2
                 ? throw new OverflowException($"Cannot convert char value '{o}' to int16")
-                : BitConverter.ToInt16(bytes),
+                : BitConverter.ToInt16(bytes, 0),
             BaseFunnyType.UInt32 => o => GetUnicodeBytes(o, out var bytes) > 4
                 ? throw new OverflowException($"Cannot convert char value '{o}' to unt32")
-                : BitConverter.ToUInt32(bytes),
+                : BitConverter.ToUInt32(bytes, 0),
             BaseFunnyType.Int32 => o => GetUnicodeBytes(o, out var bytes) > 4
                 ? throw new OverflowException($"Cannot convert char value '{o}' to int32")
-                : BitConverter.ToInt32(bytes),
+                : BitConverter.ToInt32(bytes, 0),
             BaseFunnyType.UInt64 => o => {
                 GetUnicodeBytes(o, out var bytes);
-                return BitConverter.ToUInt64(bytes);
+                return BitConverter.ToUInt64(bytes, 0);
             },
             BaseFunnyType.Int64 => o => {
                 GetUnicodeBytes(o, out var bytes);
-                return BitConverter.ToInt64(bytes);
+                return BitConverter.ToInt64(bytes, 0);
             },
             BaseFunnyType.Real => FromCharToRealConverter,
             _                  => null
@@ -232,7 +232,7 @@ public class RealIsDoubleTypeBehaviour : TypeBehaviour {
     public override bool DoubleIsReal => true;
     protected override Func<object, object> FromCharToRealConverter { get; } = o => {
         GetUnicodeBytes(o, out var bytes);
-        return (double)BitConverter.ToInt64(bytes);
+        return (double)BitConverter.ToInt64(bytes,0);
     };
 }
 
@@ -320,7 +320,7 @@ public class RealIsDecimalTypeBehaviour : TypeBehaviour {
     
     protected override Func<object, object> FromCharToRealConverter { get; } = o => {
         GetUnicodeBytes(o, out var bytes);
-        return new decimal(BitConverter.ToInt64(bytes));
+        return new decimal(BitConverter.ToInt64(bytes, 0));
     };
     
     public override bool DoubleIsReal => false;

--- a/src/Tests/NFun.ApiTests/NFun.ApiTests.csproj
+++ b/src/Tests/NFun.ApiTests/NFun.ApiTests.csproj
@@ -4,7 +4,7 @@
 
         <IsPackable>false</IsPackable>
 
-        <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netcoreapp3.1;net461</TargetFrameworks>
 
         <LangVersion>10</LangVersion>
     </PropertyGroup>

--- a/src/Tests/NFun.SyntaxTests/NFun.SyntaxTests.csproj
+++ b/src/Tests/NFun.SyntaxTests/NFun.SyntaxTests.csproj
@@ -6,7 +6,7 @@
 
         <LangVersion>10</LangVersion>
 
-        <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netcoreapp3.1;net461</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Tests/NFun.TestTools/NFun.TestTools.csproj
+++ b/src/Tests/NFun.TestTools/NFun.TestTools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netcoreapp3.1;net461</TargetFrameworks>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
 
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="NUnit" Version="3.12.0" />
+        <PackageReference Include="System.Text.Json" Version="6.0.5" />
     </ItemGroup>
 
 </Project>

--- a/src/Tests/NFun.Tic.Tests/NFun.Tic.Tests.csproj
+++ b/src/Tests/NFun.Tic.Tests/NFun.Tic.Tests.csproj
@@ -8,7 +8,7 @@
 
         <RootNamespace>NFun.Tic.Tests</RootNamespace>
 
-        <TargetFrameworks>net5.0;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;netcoreapp3.0;net461</TargetFrameworks>
 
         <LangVersion>10</LangVersion>
     </PropertyGroup>

--- a/src/Tests/Nfun.TryTicTests/Helpers.cs
+++ b/src/Tests/Nfun.TryTicTests/Helpers.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NFun.UnitTests
+{
+    public static class IEnumerableExtensions
+    {
+        public static IEnumerable<T> Append<T>(this IEnumerable<T> collection, T item)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException("Collection should not be null");
+            }
+
+            return collection.Concat(Enumerable.Repeat(item, 1));
+        }
+    }
+}

--- a/src/Tests/Nfun.TryTicTests/NFun.UnitTests.csproj
+++ b/src/Tests/Nfun.TryTicTests/NFun.UnitTests.csproj
@@ -10,7 +10,7 @@
 
         <LangVersion>10</LangVersion>
 
-        <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netcoreapp3.1;net461</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request replaces dependency from netstandart 2.1 to netstandart 2.0 ,  which allows usage of this library on .net framework platform.

Also i added .net461 target to all test projects. 