### PR TITLE
Calc does not import input properties when it is provided by an abstract type variable

### DIFF
--- a/src/NFun/Api/Calculators.cs
+++ b/src/NFun/Api/Calculators.cs
@@ -148,6 +148,63 @@ internal class CalculatorMany<TInput, TOutput> : ICalculator<TInput, TOutput> wh
     }
 }
 
+internal class CalculatorSingleDynamic<TOutput> : ICalculator<object, TOutput> {
+    private readonly FunnyCalculatorBuilder _builder;
+    private readonly MutableAprioriTypesMap _mutableApriori;
+    private readonly Memory<InputProperty> _inputsMap;
+    private readonly IOutputFunnyConverter _outputConverter;
+    public CalculatorSingleDynamic (FunnyCalculatorBuilder builder, Type inputType){
+        if (builder.Dialect.Converter.TypeBehaviour.RealType != typeof(decimal) && typeof(TOutput) == typeof(decimal))
+            throw FunnyInvalidUsageException.DecimalTypeCannotBeUsedAsOutput();
+
+        _builder = builder;
+        _mutableApriori = new MutableAprioriTypesMap();
+        _inputsMap = _mutableApriori.AddAprioriTypeInputs(inputType, Dialects.Origin.Converter);
+
+        _outputConverter = _builder.Dialect.Converter.GetOutputConverterFor(typeof(TOutput));
+        _mutableApriori.Add(Parser.AnonymousEquationId, _outputConverter.FunnyType);
+    }
+
+
+    public TOutput Calc(string expression, object inputModel) => ToLambda(expression)(inputModel);
+
+    public Func<object, TOutput> ToLambda(string expression) {
+        var runtime = _builder.CreateRuntime(expression, _mutableApriori);
+
+        FluentApiTools.ThrowIfHasUnknownInputs(runtime, _inputsMap);
+        FluentApiTools.ThrowIfHasNoDefaultOutput(runtime);
+
+        var outVariable = runtime[Parser.AnonymousEquationId];
+
+        int isRunning = 0;
+        return input => {
+            if (Interlocked.CompareExchange(ref isRunning, 1, 0) != 0)
+            {
+                // if runtime already run - create runtime copy, and run it
+                var clone = runtime.Clone();
+                return Run(clone, input, clone[Parser.AnonymousEquationId]);
+            }
+
+            try
+            {
+                return Run(runtime, input, outVariable);
+            }
+            finally
+            {
+                isRunning = 0;
+            }
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private TOutput Run(FunnyRuntime runtime, object input, IFunnyVar outVariable) {
+        FluentApiTools.SetInputValues(runtime, _inputsMap, input);
+        runtime.Run();
+        return (TOutput)_outputConverter.ToClrObject(outVariable.FunnyValue);
+    }
+}
+
+
 internal class CalculatorSingle<TInput, TOutput> : ICalculator<TInput, TOutput> {
     private readonly FunnyCalculatorBuilder _builder;
     private readonly MutableAprioriTypesMap _mutableApriori;

--- a/src/NFun/Api/FluentApiTools.cs
+++ b/src/NFun/Api/FluentApiTools.cs
@@ -6,8 +6,10 @@ using NFun.ParseErrors;
 using NFun.Runtime;
 using NFun.SyntaxParsing;
 using NFun.Types;
+using System.Globalization;
 
 namespace NFun;
+
 
 internal static class FluentApiTools {
     public static TOutput CreateOutputModelFromResults<TOutput>(FunnyRuntime runtime,Memory<OutputProperty> outputs)
@@ -121,7 +123,7 @@ internal static class FluentApiTools {
                 continue;
 
             var converter = funnyConverter.GetInputConverterFor(inputProperty.PropertyType);
-            var inputName = inputProperty.Name.ToLower();
+            var inputName = inputProperty.Name.ToLower(CultureInfo.InvariantCulture);
 
             mutableApriori.Add(inputName, converter.FunnyType);
             inputTypes[actualInputsCount] = new InputProperty(inputName,converter,inputProperty);

--- a/src/NFun/Api/FunnyCalculatorBuilder.cs
+++ b/src/NFun/Api/FunnyCalculatorBuilder.cs
@@ -112,7 +112,7 @@ public class FunnyCalculatorBuilder {
 
     public object Calc(string expression) => BuildForCalcConstant().Calc(expression);
 
-    public TOutput Calc<TOutput>(string expression, object input, Type inputType) => BuildForDynamicTypeCalc<TOutput>(inputType).Calc(expression, input);
+    public TOutput CalcDynamic<TOutput>(string expression, object input) => BuildForDynamicTypeCalc<TOutput>(input.GetType()).Calc(expression, input);
 
     public TOutput Calc<TOutput>(string expression)
         => BuildForCalcConstant<TOutput>().Calc(expression);

--- a/src/Tests/NFun.ApiTests/TestFluentApiCalcContext.cs
+++ b/src/Tests/NFun.ApiTests/TestFluentApiCalcContext.cs
@@ -112,6 +112,17 @@ public class TestFluentApiCalcContext {
             () => Funny.CalcContext(expression, new ContextModel1()));
 
     [Test]
+    public void TestImplementedModels() {
+        var inheritedModel = new InheritedModel();
+        inheritedModel.AbstractProperty = "A";
+        inheritedModel.ImplementedProperty = "B";
+
+        var calculator = new FunnyCalculatorBuilder().BuildForDynamicTypeCalc<bool>(inheritedModel.GetType());
+        Assert.True(calculator.Calc("ImplementedProperty == 'B'", inheritedModel));
+        Assert.True(calculator.Calc("AbstractProperty == 'A'", inheritedModel));
+    }
+
+    [Test]
     public void CompositeCase() {
         var origin = new ContextModel2(id: 42, inputs: new[] { 1, 2, 3, 4 },
             new[] { new UserInputModel(name: "kate", age: 33, size: 15.5) });
@@ -179,4 +190,6 @@ public class TestFluentApiCalcContext {
         FunnyAssert.AreSame(expected, c8);
         FunnyAssert.AreSame(expected, c9);
     }
+
+
 }

--- a/src/Tests/NFun.TestTools/TestModels.cs
+++ b/src/Tests/NFun.TestTools/TestModels.cs
@@ -37,6 +37,13 @@ public class ModelWithCharArray2 {
     public char[] Letters { get; set; }
 }
 
+public class InheritedModel : AbstractModel {
+    public string ImplementedProperty { get; set; }
+}
+public abstract class AbstractModel {
+    public string AbstractProperty { get; set; }
+}
+
 public class ModelWithoutEmptyConstructor {
     public ModelWithoutEmptyConstructor(string name) => Name = name;
     public string Name { get; }


### PR DESCRIPTION
There are not Calculators avaliable that allows for an abstract type variable to be provided as an input, while allowing for it's implemented properties to be correctly read.

For instance:

```
void Main()
{
	Exec(new InheritedModel()
	{
		AbstractProperty = "A",
		ImplementedProperty = "B"
	});
}
void Exec(AbstractModel model)
{
	var funny = Funny.WithFunction("lower", (string s) => s.ToLower());
	var a =	funny.Calc("AbstractProperty == 'A'", model); // This works: FluentApiTools.AddAprioriInputs correctly adds the (abstract) model's properties.
	var b = funny.Calc("ImplementedProperty == 'B'", model); // This throws an Exception: 'Some inputs are unknown'. AddAprioriInputs does not load the inherited type properties.
}

public class InheritedModel : AbstractModel
{
	public string ImplementedProperty { get; set; }
}
public abstract class AbstractModel
{
	public string AbstractProperty { get; set; }
}
```

In this case, `void Exec` does not know the implemented type - only the abstract one.
The solution I found for this (kindly point me for easier ones, if available) was to create a `AddAprioriTypeInputs` that receives a the input `Type` as parameter, loading it's properties instead of the <TInput>'s.


